### PR TITLE
ドロップダウンメニューの追加

### DIFF
--- a/components/common/Nav.vue
+++ b/components/common/Nav.vue
@@ -13,6 +13,13 @@
           :aria-label="`${item}ページに遷移する`"
           >{{ item }}</nuxt-link
         >
+        <div class="nav__spacer" />
+        <ul class="nav__dropdown">
+          <li>1</li>
+          <li>2</li>
+          <li>3</li>
+          <li>4</li>
+        </ul>
       </li>
     </ul>
   </nav>
@@ -45,16 +52,36 @@ export default {
 .nav {
   &__list {
     display: flex;
+    height: 1.5em;
 
     @include mq(desk) {
       flex-direction: column;
       align-items: center;
+      height: auto;
       color: #fff;
 
       a:hover {
         color: #dedede;
         transition: 0.3s;
       }
+    }
+  }
+
+  &__spacer {
+    height: 1.35rem;
+  }
+
+  &__dropdown {
+    height: 0;
+    overflow: hidden;
+    color: #fff;
+    text-align: center;
+    background-color: $main-color;
+    border-radius: 0 0 12px 12px;
+    transition: 0.2s;
+
+    @include mq(desk) {
+      display: none;
     }
   }
 
@@ -71,6 +98,12 @@ export default {
         margin-top: 1.5rem;
         margin-left: 0;
       }
+    }
+
+    &:hover .nav__dropdown {
+      height: auto;
+      padding: 1rem;
+      transition: 0.3s;
     }
   }
 

--- a/components/common/Nav.vue
+++ b/components/common/Nav.vue
@@ -8,17 +8,25 @@
         @click="close()"
       >
         <nuxt-link
-          :to="`/${item}`"
+          :to="`/${item.name}`"
           class="nav__link"
-          :aria-label="`${item}ページに遷移する`"
-          >{{ item }}</nuxt-link
+          :aria-label="`${item.name}ページに遷移する`"
+          >{{ item.name }}</nuxt-link
         >
         <div class="nav__spacer" />
-        <ul class="nav__dropdown">
-          <li>1</li>
-          <li>2</li>
-          <li>3</li>
-          <li>4</li>
+        <ul v-if="item.children" class="nav__dropdown">
+          <li
+            v-for="(children, childrenIndex) in item.children"
+            :key="childrenIndex"
+            class="nav__dropdownItem"
+          >
+            <nuxt-link
+              :to="`/${item.name}/${children.path}`"
+              class="nav__link -reverce"
+              :aria-label="`${children.name}ページに遷移する`"
+              >{{ children.name }}</nuxt-link
+            >
+          </li>
         </ul>
       </li>
     </ul>
@@ -32,13 +40,49 @@ export default {
   data() {
     return {
       navItems: [
-        'research',
-        'topics',
-        'advisor',
-        'education',
-        'publications',
-        'members',
-        'contact',
+        {
+          name: 'research',
+          children: [
+            {
+              name: 'ITS',
+              path: 'its',
+            },
+            {
+              name: 'Network',
+              path: 'network-architecture',
+            },
+            {
+              name: 'IoT',
+              path: 'iot',
+            },
+          ],
+        },
+        { name: 'topics' },
+        { name: 'advisor' },
+        { name: 'education' },
+        {
+          name: 'publications',
+          children: [
+            {
+              name: '2021年度',
+              path: '2021',
+            },
+            {
+              name: '2020年度',
+              path: '2020',
+            },
+            {
+              name: '2019年度',
+              path: '2019',
+            },
+            {
+              name: '2018年度',
+              path: '2018',
+            },
+          ],
+        },
+        { name: 'members' },
+        { name: 'contact' },
       ],
     }
   },
@@ -74,6 +118,7 @@ export default {
   &__dropdown {
     height: 0;
     overflow: hidden;
+    font-size: 1rem;
     color: #fff;
     text-align: center;
     background-color: $main-color;
@@ -82,6 +127,12 @@ export default {
 
     @include mq(desk) {
       display: none;
+    }
+  }
+
+  &__dropdownItem {
+    & + & {
+      padding-top: 1rem;
     }
   }
 
@@ -102,7 +153,7 @@ export default {
 
     &:hover .nav__dropdown {
       height: auto;
-      padding: 1rem;
+      padding: 1rem 0;
       transition: 0.3s;
     }
   }
@@ -114,6 +165,10 @@ export default {
 
     &:hover {
       color: #666;
+    }
+
+    &:hover.-reverce {
+      color: #ddd;
     }
 
     &::after {


### PR DESCRIPTION
取り急ぎ雑にドロップダウン実装しました 

該当箇所はグローバルナビの`research`と`publications`

<img width="1280" alt="スクリーンショット 2021-12-30 18 33 35" src="https://user-images.githubusercontent.com/55532835/147739445-f4afb06f-713c-4a60-8ba5-3e2296092154.png">

- 年度変更時に自動で最新年度が一番上に来るようにしてないので必要であればいつかやる
- 雑すぎてブランチも切り直してない
