### PR TITLE
Set Contentful client timeout to 60 seconds

### DIFF
--- a/plugins/contentful.js
+++ b/plugins/contentful.js
@@ -9,6 +9,7 @@ module.exports = {
     return contentful.createClient({
       space: config.SPACE_ID,
       accessToken: config.CTF_ACCESS_TOKEN,
+      timeout: 60000,
     })
   },
 }


### PR DESCRIPTION
Adds a 60,000ms timeout to the Contentful client configuration to prevent long-running requests and improve reliability.