### PR TITLE
Fix typo and update nav styles for desktop

### DIFF
--- a/components/common/GlobalNav.vue
+++ b/components/common/GlobalNav.vue
@@ -23,6 +23,7 @@ export default {
   display: flex;
   align-items: center;
   justify-content: center;
+  padding-top: 64px;
   overflow-y: auto;
   background-color: $main-color;
 }

--- a/components/common/Nav.vue
+++ b/components/common/Nav.vue
@@ -22,7 +22,7 @@
           >
             <nuxt-link
               :to="`/${item.name}/${children.path}`"
-              class="nav__link -reverce"
+              class="nav__link -reverse"
               :aria-label="`${children.name}ページに遷移する`"
               >{{ children.name }}</nuxt-link
             >
@@ -84,6 +84,10 @@ export default {
 
 <style lang="scss" scoped>
 .nav {
+  @include mq(desk) {
+    width: 100%;
+  }
+
   &__list {
     display: flex;
     height: 1.5em;
@@ -92,6 +96,8 @@ export default {
       flex-direction: column;
       align-items: center;
       height: auto;
+      max-height: calc(100vh - 64px - 1.35rem);
+      overflow-y: auto;
       color: #fff;
 
       a:hover {


### PR DESCRIPTION
Corrects a typo in the nav link class from '-reverce' to '-reverse'. Adds desktop-specific width, padding, and max-height with scroll for navigation components to improve layout and usability.