### PR TITLE
Improve Image and Metadata Handling for Topic Pages and Cards

### DIFF
--- a/components/common/Card.vue
+++ b/components/common/Card.vue
@@ -6,8 +6,8 @@
         <p class="card__date">{{ date }}</p>
       </div>
       <img
-        :src="img.fields ? img.fields.file.url : ''"
-        :alt="img.fields ? img.fields.description : '/nislab-ogp.png'"
+        :src="img.fields ? img.fields.file.url : 'nislab-ogp.png'"
+        :alt="img.fields ? img.fields.description : ''"
         class="card__img"
       />
     </nuxt-link>

--- a/pages/topics/_topic.vue
+++ b/pages/topics/_topic.vue
@@ -94,7 +94,7 @@ export default {
         {
           hid: 'og:url',
           property: 'og:url',
-          content: $config.baseURL + this.post.post.sys.id,
+          content: $config.baseURL + '/topics/' + this.post.post.sys.id,
         },
         {
           hid: 'og:title',
@@ -104,11 +104,9 @@ export default {
         {
           hid: 'og:image',
           property: 'og:image',
-          content:
-            'https:' +
-            (this.post.post.fields.headerImage.fields
-              ? this.post.post.fields.headerImage.fields.file.url
-              : '/nislab-ogp.png'),
+          content: this.post.post.fields.headerImage.fields
+            ? 'https:' + this.post.post.fields.headerImage.fields.file.url
+            : 'https://nislab.doshisha.ac.jp/nislab-ogp.png',
         },
       ],
     }

--- a/pages/topics/_topic.vue
+++ b/pages/topics/_topic.vue
@@ -106,7 +106,7 @@ export default {
           property: 'og:image',
           content: this.post.post.fields.headerImage.fields
             ? 'https:' + this.post.post.fields.headerImage.fields.file.url
-            : 'https://nislab.doshisha.ac.jp/nislab-ogp.png',
+            : $config.baseURL + '/nislab-ogp.png',
         },
       ],
     }


### PR DESCRIPTION
This pull request makes several improvements to how images and metadata URLs are handled for topic pages and cards. The main changes ensure that fallback images and URLs are set correctly, improving both user experience and SEO.

**Image and metadata handling improvements:**

* The fallback image source in the `Card.vue` component now uses `'nislab-ogp.png'` (relative path) when no image is present, and the alt attribute is set to an empty string if no description is available.
* The `og:url` meta tag in the topic page now correctly includes the `/topics/` path before the post ID, ensuring accurate canonical URLs for social sharing and SEO.
* The `og:image` meta tag now uses the absolute URL to the fallback image (`$config.baseURL + '/nislab-ogp.png'`) if no header image is present, rather than a relative path, which improves how the image is rendered on social platforms.