### PR TITLE
Comment out npm cache step in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,12 +19,12 @@ jobs:
         with:
           node-version: 16
 
-      # ⚡️ npm依存関係キャッシュ
-      - uses: actions/cache@v3
-        with:
-          path: |
-            **/node_modules
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+      # # ⚡️ npm依存関係キャッシュ
+      # - uses: actions/cache@v3
+      #   with:
+      #     path: |
+      #       **/node_modules
+      #     key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
 
       # 🔐 Secretsから.env生成
       - name: Create .env file
@@ -36,7 +36,7 @@ jobs:
       # 🏗️ Nuxt 2 ビルド（詳細ログ付き）
       - name: Install dependencies and build
         run: |
-          npm install --production
+          npm install --no-cache
           npm run generate
 
       # 📦 成果物をアーカイブ（distの中身だけ）


### PR DESCRIPTION
The npm dependencies cache step in the GitHub Actions deploy workflow has been commented out. Additionally, the npm install command now uses the --no-cache flag instead of --production. This may be to address caching issues or to ensure a clean install during deployment.